### PR TITLE
Remove timeout when finishing traces

### DIFF
--- a/src/eflambe_server.erl
+++ b/src/eflambe_server.erl
@@ -60,7 +60,7 @@ start_trace(Id, MaxCalls, Options) ->
 -spec stop_trace(reference()) -> {ok, boolean()}.
 
 stop_trace(Id) ->
-    gen_server:call(?SERVER, {stop_trace, Id}).
+    gen_server:call(?SERVER, {stop_trace, Id}, infinity).
 
 
 %%%===================================================================

--- a/src/eflambe_tracer.erl
+++ b/src/eflambe_tracer.erl
@@ -55,7 +55,7 @@ start_link(Options) ->
     gen_server:start_link(?MODULE, [Options], []).
 
 finish(Pid) ->
-    gen_server:call(Pid, finish).
+    gen_server:call(Pid, finish, infinity).
 
 %%%===================================================================
 %%% gen_server callbacks


### PR DESCRIPTION
Hey, while giving eflambe a try, i hit the timeouts mentioned in #3 
As it was mentioned there, I just added `infinity` to the genserver calls when finishing the traces, and then the flame graphs were generated properly

Closes #3