### PR TITLE
Fix premature stop_trace in recursive calls

### DIFF
--- a/src/eflambe.erl
+++ b/src/eflambe.erl
@@ -47,12 +47,16 @@ capture({Module, Function, Arity}, NumCalls, Options)
     TraceId = setup_for_trace(),
 
     ShimmedFunction = fun(Args) ->
-        Trace = start_trace(TraceId, NumCalls, [{meck, Module}|Options]),
-
+        {Trace, StartedNew} = start_trace(TraceId, NumCalls, [{meck, Module}|Options]),
         % Invoke the original function
         Results = meck:passthrough(Args),
 
-        stop_trace(Trace),
+        case StartedNew of
+            true ->
+                stop_trace(Trace);
+            false ->
+                ok
+        end,
         Results
     end,
 
@@ -102,7 +106,8 @@ apply({Function, Args}, Options) when is_function(Function), is_list(Args) ->
 %%% Internal functions
 %%%===================================================================
 
--spec start_trace(TraceId :: any(), NumCalls :: integer(), Options :: list()) -> reference().
+-spec start_trace(TraceId :: any(), NumCalls :: integer(), Options :: list()) ->
+    {reference(), boolean()}.
 
 start_trace(TraceId, NumCalls, Options) ->
     case eflambe_server:start_trace(TraceId, NumCalls, Options) of
@@ -110,14 +115,13 @@ start_trace(TraceId, NumCalls, Options) ->
             MatchSpec = [{'_', [], [{message, {{cp, {caller}}}}]}],
             erlang:trace_pattern(on_load, MatchSpec, [local]),
             erlang:trace_pattern({'_', '_', '_'}, MatchSpec, [local]),
-            erlang:trace(self(), true, [{tracer, Tracer} | ?FLAGS]);
+            erlang:trace(self(), true, [{tracer, Tracer} | ?FLAGS]),
+            {TraceId, true};
         {ok, TraceId, false, _Tracer} ->
             % Trace is already running or has already finished. Or this could
             % be a recursive function call.  We do not need to do anything.
-            ok
-    end,
-
-    TraceId.
+            {TraceId, false}
+    end.
 
 -spec stop_trace(any()) -> ok.
 


### PR DESCRIPTION
While eFlambe correctly detects that a trace is already running (e.g. in a recursive situation) and doesn't start it again, it still stops the trace when that internal recursive call completes, instead of waiting for the top level call that started the trace to complete. This results in truncated traces and also a `not_mocked` error when the outer call tries to unload meck.

This PR resolves this by only unloading meck when the call that started the trace terminates.