### PR TITLE
fix example in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -66,8 +66,8 @@ For profiling a function that you want to invoke directly.
 
 [source, erlang]
 ----
-eflambe:capture({Module :: atom(), Function :: atom(), Args :: list()}, NumberOfCallsToProfile :: integer(), Options :: list()).
-eflambe:capture(Fun :: fun(), NumberOfCallsToProfile :: integer(), Options :: list()).
+eflambe:apply({Module :: atom(), Function :: atom(), Args :: list()}, Options :: list()).
+eflambe:apply(Fun :: fun(), Options :: list()).
 ----
 
 Example:


### PR DESCRIPTION
Looks like the `apply` examples in the README might have been copied from `capture` and not updated. Fixed them to reflect `apply`