### PR TITLE
Spec fixes for option and NumCalls

### DIFF
--- a/src/eflambe.erl
+++ b/src/eflambe.erl
@@ -14,7 +14,7 @@
 -type mfa_fun() :: {atom(), atom(), list()} | fun().
 
 -type program() :: hotspot | speedscope.
--type option() :: {output_directory, binary()} | {output_format, binary()} | {open, program()}.
+-type option() :: {output_directory, binary()} | {output_format, brendan_gregg} | {open, program()}.
 -type options() :: [option()].
 
 -define(FLAGS, [call, return_to, running, procs, garbage_collection, arity,
@@ -34,12 +34,12 @@
 capture(MFA) ->
     capture(MFA, 1).
 
--spec capture(MFA :: mfa(), NumCalls :: integer()) -> ok.
+-spec capture(MFA :: mfa(), NumCalls :: pos_integer()) -> ok.
 
 capture(MFA, NumCalls) ->
     capture(MFA, NumCalls, []).
 
--spec capture(MFA :: mfa(), NumCalls :: integer(), Options :: options()) -> ok.
+-spec capture(MFA :: mfa(), NumCalls :: pos_integer(), Options :: options()) -> ok.
 
 capture({Module, Function, Arity}, NumCalls, Options)
   when is_atom(Module), is_atom(Function), is_integer(Arity) ->
@@ -106,7 +106,7 @@ apply({Function, Args}, Options) when is_function(Function), is_list(Args) ->
 %%% Internal functions
 %%%===================================================================
 
--spec start_trace(TraceId :: any(), NumCalls :: integer(), Options :: list()) ->
+-spec start_trace(TraceId :: any(), NumCalls :: pos_integer(), Options :: list()) ->
     {reference(), boolean()}.
 
 start_trace(TraceId, NumCalls, Options) ->


### PR DESCRIPTION
Hello!

I have been enjoying generating flamegraphs, thank you for the library!

I was getting a dialyzer error for options as the specs expected a binary, but I believe that the atom `brendan_gregg` is the only thing that can be accepted by code. I verified that this change fixed the error.

The `NumCalls` integer -> pos_integer is a change that I think is correct (because there is no point in calling the function for 0 calls, and negative calls breaks the space time continuum?) but was not the result of a dialyzer error.

Cheers!