### PR TITLE
Return meck error when `eflambe:capture/3` is called on the same module twice

### DIFF
--- a/test/helloworld.erl
+++ b/test/helloworld.erl
@@ -1,0 +1,6 @@
+-module(helloworld).
+
+-export([greet/1]).
+
+greet(Name) ->
+    io:format("Hello ~p~n", [Name]).


### PR DESCRIPTION
A module can only be mocked once with meck, so it is not permitted have two `capture`s of a module with `eflambe:capture/3` running at the same time. With these changes we return an error instead of crashing.